### PR TITLE
Replace outdated difflib with diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "core-js": "^3.41.0",
-    "difflib": "^0.2.4",
+    "diff": "^7.0.0",
     "docx": "^8.5.0",
     "draft-js": "^0.11.7",
     "everpolate": "0.0.3",


### PR DESCRIPTION
Replace `difflib` with `diff` an outdated library, which was still using ES5. This is to get rid of the following error introduced in https://github.com/qiao/difflib.js/blob/e11553ba3e303e2db206d04c95f8e51c5692ca28/lib/difflib.js#L78: 
```
Uncaught TypeError: Cannot assign to read only property 'name' of function 'function e(e,t,n,r){this.isjunk=e,null==t&&(t=""),null==n&&(n=""),this.autojunk=null==r||r,this.a=this.b=null,this.setSeqs(t,n)}'
```